### PR TITLE
feat: actions and requirements now accept the Target object

### DIFF
--- a/art-bukkit/src/main/java/net/silthus/art/ArtPlugin.java
+++ b/art-bukkit/src/main/java/net/silthus/art/ArtPlugin.java
@@ -17,7 +17,7 @@
 package net.silthus.art;
 
 import com.google.inject.Binder;
-import kr.entree.spigradle.Plugin;
+import kr.entree.spigradle.PluginMain;
 import lombok.Getter;
 import net.silthus.art.api.ArtManager;
 import net.silthus.art.api.scheduler.Scheduler;
@@ -30,7 +30,7 @@ import org.bukkit.plugin.ServicePriority;
 
 import javax.inject.Inject;
 
-@Plugin
+@PluginMain
 public class ArtPlugin extends BasePlugin {
 
     @Inject

--- a/art-bukkit/src/main/java/net/silthus/art/EntityWorldFilter.java
+++ b/art-bukkit/src/main/java/net/silthus/art/EntityWorldFilter.java
@@ -18,6 +18,7 @@ package net.silthus.art;
 
 import net.silthus.art.api.config.ArtConfig;
 import net.silthus.art.api.parser.ArtResultFilter;
+import net.silthus.art.api.trigger.Target;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 
@@ -26,10 +27,10 @@ import java.util.List;
 public class EntityWorldFilter implements ArtResultFilter<Entity> {
 
     @Override
-    public boolean test(Entity entity, ArtConfig config) {
+    public boolean test(Target<Entity> entity, ArtConfig config) {
         List<String> worlds = config.getOptions().getWorlds();
         if (worlds.size() > 0) {
-            World world = entity.getLocation().getWorld();
+            World world = entity.getSource().getLocation().getWorld();
             return world == null || worlds.contains(world.getName());
         }
         return true;

--- a/art-core/src/main/java/net/silthus/art/ART.java
+++ b/art-core/src/main/java/net/silthus/art/ART.java
@@ -26,7 +26,6 @@ import net.silthus.art.api.parser.ArtResult;
 import net.silthus.art.api.trigger.Target;
 import net.silthus.art.api.trigger.TriggerContext;
 
-import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +91,7 @@ public final class ART {
      * Use this method to create and load an {@link ArtResult} from your {@link ArtConfig}.
      * <br>
      * You can then use the {@link ArtResult} to invoke {@link Action}s by calling
-     * {@link ArtResult#execute(Object)} or to check for requirements by calling {@link ArtResult#test(Object)}.
+     * {@link ArtResult#execute(Target)} or to check for requirements by calling {@link ArtResult#test(Target)}.
      * <br>
      *
      * @param config config to parse and create ART from
@@ -113,9 +112,8 @@ public final class ART {
         getInstance().ifPresent(artManager -> artManager.trigger(identifier, predicate, targets));
     }
 
-    @Nullable
-    public static <TTarget> Target<TTarget> getTarget(@NonNull TTarget target) {
+    public static <TTarget> Optional<Target<TTarget>> getTarget(@NonNull TTarget target) {
 
-        return getInstance().map(artManager -> artManager.getTarget(target)).orElse(null);
+        return getInstance().flatMap(artManager -> artManager.getTarget(target));
     }
 }

--- a/art-core/src/main/java/net/silthus/art/DefaultArtResult.java
+++ b/art-core/src/main/java/net/silthus/art/DefaultArtResult.java
@@ -58,14 +58,14 @@ public final class DefaultArtResult implements ArtResult, TriggerListener<Object
     }
 
     @Override
-    public final <TTarget> boolean test(TTarget target) {
+    public final <TTarget> boolean test(Target<TTarget> target) {
 
-        return test(target, new ArrayList<>());
+        return test(target, new ArrayList<ArtResultFilter<TTarget>>());
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public final <TTarget> boolean test(TTarget target, Collection<ArtResultFilter<TTarget>> filters) {
+    public final <TTarget> boolean test(Target<TTarget> target, Collection<ArtResultFilter<TTarget>> filters) {
 
         if (Objects.isNull(target)) return false;
 
@@ -77,14 +77,14 @@ public final class DefaultArtResult implements ArtResult, TriggerListener<Object
     }
 
     @Override
-    public final <TTarget> void execute(TTarget target) {
+    public final <TTarget> void execute(Target<TTarget> target) {
 
-        execute(target, new ArrayList<>());
+        execute(target, new ArrayList<ArtResultFilter<TTarget>>());
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <TTarget> void execute(TTarget target, Collection<ArtResultFilter<TTarget>> filters) {
+    public <TTarget> void execute(Target<TTarget> target, Collection<ArtResultFilter<TTarget>> filters) {
 
         if (Objects.isNull(target)) return;
         if (!testFilter(target, filters)) return;
@@ -110,18 +110,18 @@ public final class DefaultArtResult implements ArtResult, TriggerListener<Object
     public void onTrigger(@NonNull Target target) {
         if (test(target)) {
             execute(target);
-            getEntryForTarget(target.getTarget(), triggerListeners)
+            getEntryForTarget(target.getSource(), triggerListeners)
                     .orElse(new ArrayList<>())
                     .forEach(triggerListener -> triggerListener.onTrigger(target));
         }
     }
 
-    private <TTarget> boolean testFilter(TTarget target, Collection<ArtResultFilter<TTarget>> filters) {
+    private <TTarget> boolean testFilter(Target<TTarget> target, Collection<ArtResultFilter<TTarget>> filters) {
         return filters.stream().allMatch(filter -> filter.test(target, config));
     }
 
     @SuppressWarnings("unchecked")
-    private <TTarget> boolean testGlobalFilter(TTarget target) {
+    private <TTarget> boolean testGlobalFilter(Target<TTarget> target) {
 
         if (Objects.isNull(target)) return false;
 

--- a/art-core/src/main/java/net/silthus/art/api/Action.java
+++ b/art-core/src/main/java/net/silthus/art/api/Action.java
@@ -17,6 +17,7 @@
 package net.silthus.art.api;
 
 import net.silthus.art.api.actions.ActionContext;
+import net.silthus.art.api.trigger.Target;
 
 /**
  * Defines an action that can get executed if the right {@link Trigger} was called.
@@ -45,5 +46,5 @@ public interface Action<TTarget, TConfig> extends ArtObject {
      *                Use the {@link ActionContext} to retrieve the config
      *                and additional information about the execution context of this action.
      */
-    void execute(TTarget target, ActionContext<TTarget, TConfig> context);
+    void execute(Target<TTarget> target, ActionContext<TTarget, TConfig> context);
 }

--- a/art-core/src/main/java/net/silthus/art/api/ArtContext.java
+++ b/art-core/src/main/java/net/silthus/art/api/ArtContext.java
@@ -1,15 +1,15 @@
 package net.silthus.art.api;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import net.silthus.art.api.config.ArtObjectConfig;
+import net.silthus.art.api.trigger.Target;
 
 import java.util.Objects;
 import java.util.Optional;
 
 public abstract class ArtContext<TTarget, TConfig, TContextOptions extends ArtObjectConfig<TConfig>> {
 
-    @Getter(AccessLevel.PACKAGE)
+    @Getter
     private final Class<TTarget> targetClass;
     private final TContextOptions config;
 
@@ -40,7 +40,11 @@ public abstract class ArtContext<TTarget, TConfig, TContextOptions extends ArtOb
      * @param target target object to test
      * @return true if types match
      */
+    @SuppressWarnings("rawtypes")
     public boolean isTargetType(Object target) {
+        if (target instanceof Target) {
+            return getTargetClass().isInstance(((Target) target).getSource());
+        }
         return getTargetClass().isInstance(target);
     }
 }

--- a/art-core/src/main/java/net/silthus/art/api/ArtManager.java
+++ b/art-core/src/main/java/net/silthus/art/api/ArtManager.java
@@ -28,9 +28,9 @@ import net.silthus.art.api.parser.ArtResultFilter;
 import net.silthus.art.api.trigger.Target;
 import net.silthus.art.api.trigger.TriggerContext;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -75,11 +75,10 @@ public interface ArtManager {
     /**
      * Wraps the given target object into a {@link Target}.
      *
-     * @param target target to wrap
+     * @param target    target to wrap
      * @param <TTarget> target type
      * @return wrapped target
      * @see ART#getTarget(Object)
      */
-    @Nullable
-    <TTarget> Target<TTarget> getTarget(@NonNull TTarget target);
+    <TTarget> Optional<Target<TTarget>> getTarget(@NonNull TTarget target);
 }

--- a/art-core/src/main/java/net/silthus/art/api/Requirement.java
+++ b/art-core/src/main/java/net/silthus/art/api/Requirement.java
@@ -19,6 +19,7 @@ package net.silthus.art.api;
 import net.silthus.art.ART;
 import net.silthus.art.ArtModuleDescription;
 import net.silthus.art.api.requirements.RequirementContext;
+import net.silthus.art.api.trigger.Target;
 
 import java.util.function.Consumer;
 
@@ -52,5 +53,5 @@ public interface Requirement<TTarget, TConfig> extends ArtObject {
      * @param context {@link RequirementContext} that holds the config and context of the check
      * @return false if the check fails and the filter should be applied or true if all checks pass and no filtering should be applied.
      */
-    boolean test(TTarget target, RequirementContext<TTarget, TConfig> context);
+    boolean test(Target<TTarget> target, RequirementContext<TTarget, TConfig> context);
 }

--- a/art-core/src/main/java/net/silthus/art/api/Trigger.java
+++ b/art-core/src/main/java/net/silthus/art/api/Trigger.java
@@ -21,6 +21,7 @@ import net.silthus.art.api.trigger.Target;
 import net.silthus.art.api.trigger.TriggerContext;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public interface Trigger extends ArtObject {
@@ -30,6 +31,10 @@ public interface Trigger extends ArtObject {
     }
 
     default <TConfig> void trigger(String identifier, Predicate<TriggerContext<TConfig>> context, Object... targets) {
-        ART.trigger(identifier, context, Arrays.stream(targets).map(Target::of).toArray(Target[]::new));
+        ART.trigger(identifier, context, Arrays.stream(targets)
+                .map(Target::of)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toArray(Target[]::new));
     }
 }

--- a/art-core/src/main/java/net/silthus/art/api/actions/ActionHolder.java
+++ b/art-core/src/main/java/net/silthus/art/api/actions/ActionHolder.java
@@ -1,5 +1,7 @@
 package net.silthus.art.api.actions;
 
+import net.silthus.art.api.trigger.Target;
+
 import java.util.Collection;
 
 public interface ActionHolder {
@@ -9,7 +11,7 @@ public interface ActionHolder {
     Collection<ActionContext<?, ?>> getActions();
 
     @SuppressWarnings("unchecked")
-    default <TTarget> void executeActions(TTarget target) {
+    default <TTarget> void executeActions(Target<TTarget> target) {
         getActions().stream()
                 .filter(actionContext -> actionContext.isTargetType(target))
                 .map(actionContext -> (ActionContext<TTarget, ?>) actionContext)

--- a/art-core/src/main/java/net/silthus/art/api/parser/ArtResultFilter.java
+++ b/art-core/src/main/java/net/silthus/art/api/parser/ArtResultFilter.java
@@ -17,6 +17,7 @@
 package net.silthus.art.api.parser;
 
 import net.silthus.art.api.config.ArtConfig;
+import net.silthus.art.api.trigger.Target;
 
 import java.util.function.BiPredicate;
 
@@ -26,5 +27,5 @@ import java.util.function.BiPredicate;
  * @param <TTarget> target type to apply filter to
  */
 @FunctionalInterface
-public interface ArtResultFilter<TTarget> extends BiPredicate<TTarget, ArtConfig> {
+public interface ArtResultFilter<TTarget> extends BiPredicate<Target<TTarget>, ArtConfig> {
 }

--- a/art-core/src/main/java/net/silthus/art/api/requirements/RequirementContext.java
+++ b/art-core/src/main/java/net/silthus/art/api/requirements/RequirementContext.java
@@ -17,8 +17,10 @@
 package net.silthus.art.api.requirements;
 
 import lombok.Getter;
+import lombok.NonNull;
 import net.silthus.art.api.ArtContext;
 import net.silthus.art.api.Requirement;
+import net.silthus.art.api.trigger.Target;
 
 import java.util.Objects;
 
@@ -40,20 +42,18 @@ public class RequirementContext<TTarget, TConfig> extends ArtContext<TTarget, TC
         this.requirement = requirement;
     }
 
-    public final boolean test(TTarget target) {
+    public final boolean test(@NonNull Target<TTarget> target) {
 
         return test(target, this);
     }
 
     @Override
-    public boolean test(TTarget target, RequirementContext<TTarget, TConfig> context) {
+    public boolean test(@NonNull Target<TTarget> target, RequirementContext<TTarget, TConfig> context) {
 
         if (context != null && context != this)
             throw new UnsupportedOperationException("RequirementContext#test(target, context) must not be called directly. Use ActionResult#test(target) instead.");
 
-        Objects.requireNonNull(target, "target must not be null");
-
-        if (!isTargetType(target)) return true;
+        if (!isTargetType(target.getSource())) return true;
 
         return getRequirement().test(target, Objects.isNull(context) ? this : context);
     }

--- a/art-core/src/main/java/net/silthus/art/api/requirements/RequirementHolder.java
+++ b/art-core/src/main/java/net/silthus/art/api/requirements/RequirementHolder.java
@@ -1,5 +1,7 @@
 package net.silthus.art.api.requirements;
 
+import net.silthus.art.api.trigger.Target;
+
 import java.util.Collection;
 
 public interface RequirementHolder {
@@ -9,7 +11,7 @@ public interface RequirementHolder {
     Collection<RequirementContext<?, ?>> getRequirements();
 
     @SuppressWarnings("unchecked")
-    default <TTarget> boolean testRequirements(TTarget target) {
+    default <TTarget> boolean testRequirements(Target<TTarget> target) {
         return getRequirements().stream()
                 .filter(requirementContext -> requirementContext.isTargetType(target))
                 .map(requirementContext -> (RequirementContext<TTarget, ?>) requirementContext)

--- a/art-core/src/main/java/net/silthus/art/api/trigger/AbstractTarget.java
+++ b/art-core/src/main/java/net/silthus/art/api/trigger/AbstractTarget.java
@@ -18,15 +18,14 @@ package net.silthus.art.api.trigger;
 
 import lombok.Getter;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public abstract class AbstractTarget<TTarget> implements Target<TTarget> {
 
     @Getter
-    private final TTarget target;
+    private final TTarget source;
 
-    protected AbstractTarget(TTarget target) {
-        this.target = target;
+    protected AbstractTarget(TTarget source) {
+        this.source = source;
     }
 
     @Override
@@ -38,15 +37,12 @@ public abstract class AbstractTarget<TTarget> implements Target<TTarget> {
         AbstractTarget<?> that = (AbstractTarget<?>) o;
 
         return new EqualsBuilder()
-                .append(getTarget(), that.getTarget())
+                .append(getUniqueId(), that.getUniqueId())
                 .isEquals();
     }
 
     @Override
     public final int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(getUniqueId())
-                .append(getTarget())
-                .toHashCode();
+        return getUniqueId().hashCode();
     }
 }

--- a/art-core/src/main/java/net/silthus/art/api/trigger/Target.java
+++ b/art-core/src/main/java/net/silthus/art/api/trigger/Target.java
@@ -22,7 +22,7 @@ import net.silthus.art.ArtBuilder;
 import net.silthus.art.ArtModuleDescription;
 import net.silthus.art.api.Trigger;
 
-import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -43,12 +43,11 @@ public interface Target<TTarget> {
      * It will try to find the best possible (nearest) wrapper
      * and will return null if no wrapper was found.
      *
-     * @param target target to wrap
+     * @param target    target to wrap
      * @param <TTarget> type of the target
      * @return wrapped target object or null if no wrapper was found
      */
-    @Nullable
-    static <TTarget> Target<TTarget> of(@NonNull TTarget target) {
+    static <TTarget> Optional<Target<TTarget>> of(@NonNull TTarget target) {
         return ART.getTarget(target);
     }
 
@@ -71,5 +70,5 @@ public interface Target<TTarget> {
      * @return wrapped target object
      */
     @NonNull
-    TTarget getTarget();
+    TTarget getSource();
 }

--- a/art-core/src/main/java/net/silthus/art/api/trigger/TriggerContext.java
+++ b/art-core/src/main/java/net/silthus/art/api/trigger/TriggerContext.java
@@ -86,7 +86,7 @@ public class TriggerContext<TConfig> extends ArtContext<Object, TConfig, Trigger
         if (predicate.test(this) && testRequirements(target)) {
             executeActions(target);
 
-            getEntryForTarget(target.getTarget(), listeners).orElse(new HashSet<>()).stream()
+            getEntryForTarget(target.getSource(), listeners).orElse(new HashSet<>()).stream()
                     .map(triggerListener -> (TriggerListener<TTarget>) triggerListener)
                     .forEach(listener -> listener.onTrigger(target));
         }

--- a/art-core/src/main/java/net/silthus/art/util/ReflectionUtil.java
+++ b/art-core/src/main/java/net/silthus/art/util/ReflectionUtil.java
@@ -1,5 +1,7 @@
 package net.silthus.art.util;
 
+import net.silthus.art.api.trigger.Target;
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -33,7 +35,12 @@ public final class ReflectionUtil {
      * @param <TResult> result type of the map
      * @return extracted map value if the target type matched and was found
      */
+    @SuppressWarnings("unchecked")
     public static <TTarget, TResult> Optional<TResult> getEntryForTarget(TTarget target, Map<Class<?>, TResult> map) {
+
+        if (target instanceof Target) {
+            target = ((Target<TTarget>) target).getSource();
+        }
 
         Class<?> targetClass = target.getClass();
         if (map.containsKey(targetClass)) {

--- a/art-core/src/test/java/net/silthus/art/DefaultArtManagerTest.java
+++ b/art-core/src/test/java/net/silthus/art/DefaultArtManagerTest.java
@@ -107,10 +107,10 @@ class DefaultArtManagerTest {
     class getTarget {
 
         @Test
-        @DisplayName("should return null if not found")
+        @DisplayName("should return empty optional if not found")
         void shouldReturnNullIfNotFound() {
 
-            assertThat(artManager.getTarget("foobar")).isNull();
+            assertThat(artManager.getTarget("foobar")).isEmpty();
         }
 
         @Test
@@ -121,7 +121,8 @@ class DefaultArtManagerTest {
             artManager.getTargetWrapper().put(MyTarget.class, o -> new MyTargetWrapper((MyTarget) o));
 
             assertThat(artManager.getTarget(new MyTarget()))
-                    .isNotNull()
+                    .isNotEmpty()
+                    .get()
                     .isInstanceOf(MyTargetWrapper.class);
         }
 
@@ -132,7 +133,8 @@ class DefaultArtManagerTest {
             artManager.getTargetWrapper().put(MySuperTarget.class, o -> new MySuperTargetWrapper<>((MySuperTarget) o));
 
             assertThat(artManager.getTarget(new MyTarget()))
-                    .isNotNull()
+                    .isNotEmpty()
+                    .get()
                     .isInstanceOf(MySuperTargetWrapper.class);
         }
 
@@ -143,7 +145,8 @@ class DefaultArtManagerTest {
             artManager.getTargetWrapper().put(MyTarget.class, o -> new MyTargetWrapper((MyTarget) o));
 
             assertThat(artManager.getTarget(new MyLowTarget()))
-                    .isNotNull()
+                    .isNotEmpty()
+                    .get()
                     .isInstanceOf(MyTargetWrapper.class);
         }
 
@@ -167,7 +170,7 @@ class DefaultArtManagerTest {
             }
 
             @Override
-            public TTarget getTarget() {
+            public TTarget getSource() {
                 return target;
             }
         }

--- a/art-core/src/test/java/net/silthus/art/api/TestUtil.java
+++ b/art-core/src/test/java/net/silthus/art/api/TestUtil.java
@@ -1,10 +1,11 @@
-package net.silthus.art;
+package net.silthus.art.api;
 
 import net.silthus.art.api.actions.ActionContext;
 import net.silthus.art.api.requirements.RequirementContext;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public final class TestUtil {
@@ -17,23 +18,25 @@ public final class TestUtil {
 
     public static <TTarget> ActionContext<TTarget, ?> action(Class<TTarget> targetClass) {
         ActionContext<TTarget, ?> action = mock(ActionContext.class);
-        when(action.isTargetType(any(targetClass))).thenReturn(true);
+        when(action.isTargetType(any())).thenCallRealMethod();
+        when(action.getTargetClass()).thenReturn(targetClass);
         return action;
     }
 
     public static RequirementContext<?, ?> requirement(boolean result) {
         RequirementContext requirement = mock(RequirementContext.class);
-        doReturn(true).when(requirement).isTargetType(any());
-        doReturn(result).when(requirement).test(any());
-        doReturn(result).when(requirement).test(any(), any());
+        when(requirement.isTargetType(any())).thenReturn(true);
+        when(requirement.test(any(), any())).thenReturn(result);
+        when(requirement.test(any())).thenReturn(result);
         return requirement;
     }
 
     public static <TTarget> RequirementContext<TTarget, ?> requirement(Class<TTarget> targetClass, boolean result) {
         RequirementContext requirement = mock(RequirementContext.class);
-        doReturn(true).when(requirement).isTargetType(any(targetClass));
-        doReturn(result).when(requirement).test(any(targetClass));
-        doReturn(result).when(requirement).test(any(targetClass), any());
+        when(requirement.getTargetClass()).thenReturn(targetClass);
+        when(requirement.isTargetType(any())).thenCallRealMethod();
+        when(requirement.test(any(), any())).thenReturn(result);
+        when(requirement.test(any())).thenReturn(result);
         return requirement;
     }
 }

--- a/art-core/src/test/java/net/silthus/art/api/factory/ArtFactoryTest.java
+++ b/art-core/src/test/java/net/silthus/art/api/factory/ArtFactoryTest.java
@@ -26,6 +26,7 @@ import net.silthus.art.api.actions.ActionContext;
 import net.silthus.art.api.actions.ActionFactory;
 import net.silthus.art.api.annotations.*;
 import net.silthus.art.api.config.ConfigFieldInformation;
+import net.silthus.art.api.trigger.Target;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -161,7 +162,8 @@ public class ArtFactoryTest {
                 @Name("foo")
                 @Config(TestConfig.class)
                 @Override
-                public void execute(String s, ActionContext<String, TestConfig> context) {}
+                public void execute(Target<String> s, ActionContext<String, TestConfig> context) {
+                }
             });
 
             assertThatCode(() -> factory.initialize()).doesNotThrowAnyException();
@@ -279,7 +281,7 @@ public class ArtFactoryTest {
                     @Name("test")
                     @Config(ErrorConfig.class)
                     @Override
-                    public void execute(String s, ActionContext<String, ErrorConfig> context) {
+                    public void execute(Target<String> s, ActionContext<String, ErrorConfig> context) {
 
                     }
                 });
@@ -319,7 +321,7 @@ public class ArtFactoryTest {
     @Config(TestConfig.class)
     public static class TestAction implements Action<String, TestConfig> {
         @Override
-        public void execute(String s, ActionContext<String, TestConfig> context) {
+        public void execute(Target<String> s, ActionContext<String, TestConfig> context) {
 
         }
     }

--- a/art-core/src/test/java/net/silthus/art/api/requirements/RequirementContextTest.java
+++ b/art-core/src/test/java/net/silthus/art/api/requirements/RequirementContextTest.java
@@ -1,12 +1,14 @@
 package net.silthus.art.api.requirements;
 
 import net.silthus.art.api.Requirement;
+import net.silthus.art.testing.IntegerTarget;
+import net.silthus.art.testing.StringTarget;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static net.silthus.art.TestUtil.requirement;
+import static net.silthus.art.api.TestUtil.requirement;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.*;
@@ -69,8 +71,8 @@ class RequirementContextTest {
         void shouldInvokeTestWithContext() {
 
             RequirementContext context = spy(RequirementContextTest.this.context);
-            assertThat(context.test("foo")).isTrue();
-            verify(context, times(1)).test("foo", context);
+            assertThat(context.test(new StringTarget("foo"))).isTrue();
+            verify(context, times(1)).test(new StringTarget("foo"), context);
         }
 
         @Test
@@ -79,7 +81,7 @@ class RequirementContextTest {
 
             assertThatExceptionOfType(NullPointerException.class)
                     .isThrownBy(() -> context.test(null))
-                    .withMessage("target must not be null");
+                    .withMessage("target is marked non-null but is null");
         }
 
         @Test
@@ -88,7 +90,7 @@ class RequirementContextTest {
 
             RequirementContext context = spy(withRequirement(requirement(String.class, false)));
 
-            assertThat(context.test(2)).isTrue();
+            assertThat(context.test(new IntegerTarget(2))).isTrue();
             verify(context, times(1)).isTargetType(2);
         }
 
@@ -99,8 +101,8 @@ class RequirementContextTest {
             RequirementContext<String, ?> requirement = requirement(String.class, true);
             RequirementContext<String, ?> context = withRequirement(String.class, requirement);
 
-            assertThat(context.test("foo")).isTrue();
-            verify(requirement, times(1)).test("foo", (RequirementContext) context);
+            assertThat(context.test(new StringTarget("foo"))).isTrue();
+            verify(requirement, times(1)).test(new StringTarget("foo"), (RequirementContext) context);
         }
     }
 
@@ -113,7 +115,7 @@ class RequirementContextTest {
         void shouldThrowIfCalledDirectly() {
 
             assertThatExceptionOfType(UnsupportedOperationException.class)
-                    .isThrownBy(() -> context.test("foobar", new RequirementContext(String.class, requirement, new RequirementConfig<>())))
+                    .isThrownBy(() -> context.test(new StringTarget("foobar"), new RequirementContext(String.class, requirement, new RequirementConfig<>())))
                     .withMessageContaining("RequirementContext#test(target, context) must not be called directly");
 
         }

--- a/art-core/src/test/java/net/silthus/art/testing/IntegerTarget.java
+++ b/art-core/src/test/java/net/silthus/art/testing/IntegerTarget.java
@@ -1,0 +1,19 @@
+package net.silthus.art.testing;
+
+import lombok.Data;
+import net.silthus.art.api.trigger.Target;
+
+@Data
+public class IntegerTarget implements Target<Integer> {
+
+    private final int source;
+
+    @Override
+    public String getUniqueId() {
+        return hashCode() + "";
+    }
+
+    public Integer getSource() {
+        return source;
+    }
+}

--- a/art-core/src/test/java/net/silthus/art/testing/StringTarget.java
+++ b/art-core/src/test/java/net/silthus/art/testing/StringTarget.java
@@ -1,15 +1,15 @@
 package net.silthus.art.testing;
 
-import lombok.Data;
-import net.silthus.art.api.trigger.Target;
+import net.silthus.art.api.trigger.AbstractTarget;
 
-@Data
-public class StringTarget implements Target<String> {
+public class StringTarget extends AbstractTarget<String> {
 
-    private final String target;
+    public StringTarget(String source) {
+        super(source);
+    }
 
     @Override
     public String getUniqueId() {
-        return target.hashCode() + "";
+        return getSource();
     }
 }

--- a/art-core/src/test/java/net/silthus/art/util/ReflectionUtilTest.java
+++ b/art-core/src/test/java/net/silthus/art/util/ReflectionUtilTest.java
@@ -117,7 +117,7 @@ class ReflectionUtilTest {
             }
 
             @Override
-            public TTarget getTarget() {
+            public TTarget getSource() {
                 return target;
             }
         }

--- a/art-example/src/main/java/net/silthus/examples/art/ExampleArtPlugin.java
+++ b/art-example/src/main/java/net/silthus/examples/art/ExampleArtPlugin.java
@@ -17,7 +17,7 @@
 package net.silthus.examples.art;
 
 import de.exlll.configlib.configs.yaml.YamlConfiguration;
-import kr.entree.spigradle.Plugin;
+import kr.entree.spigradle.PluginMain;
 import lombok.Getter;
 import lombok.Setter;
 import net.silthus.art.ART;
@@ -36,7 +36,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 
-@Plugin
+@PluginMain
 public class ExampleArtPlugin extends JavaPlugin {
 
     @Getter

--- a/art-example/src/main/java/net/silthus/examples/art/actions/PlayerDamageAction.java
+++ b/art-example/src/main/java/net/silthus/examples/art/actions/PlayerDamageAction.java
@@ -16,9 +16,11 @@
 
 package net.silthus.examples.art.actions;
 
+import lombok.NonNull;
 import net.silthus.art.api.Action;
 import net.silthus.art.api.actions.ActionContext;
 import net.silthus.art.api.annotations.*;
+import net.silthus.art.api.trigger.Target;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
@@ -38,13 +40,14 @@ public class PlayerDamageAction implements Action<Player, PlayerDamageAction.Act
     /**
      * This method will be called everytime your action is executed.
      *
-     * @param player the player or other target object your action is executed against
+     * @param target  the player or other target object your action is executed against
      * @param context context of this action.
      *                Use the {@link ActionContext} to retrieve the config
      */
     @Override
-    public void execute(Player player, ActionContext<Player, ActionConfig> context) {
+    public void execute(Target<Player> target, ActionContext<Player, ActionConfig> context) {
         context.getConfig().ifPresent(config -> {
+            @NonNull Player player = target.getSource();
             double damage;
             double health = player.getHealth();
             AttributeInstance attribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);

--- a/art-example/src/main/java/net/silthus/examples/art/requirements/EntityLocationRequirement.java
+++ b/art-example/src/main/java/net/silthus/examples/art/requirements/EntityLocationRequirement.java
@@ -21,6 +21,7 @@ import net.silthus.art.api.annotations.Config;
 import net.silthus.art.api.annotations.Description;
 import net.silthus.art.api.annotations.Name;
 import net.silthus.art.api.requirements.RequirementContext;
+import net.silthus.art.api.trigger.Target;
 import net.silthus.examples.art.configs.LocationConfig;
 import org.bukkit.entity.Entity;
 
@@ -34,12 +35,12 @@ import org.bukkit.entity.Entity;
 public class EntityLocationRequirement implements Requirement<Entity, LocationConfig> {
 
     @Override
-    public boolean test(Entity entity, RequirementContext<Entity, LocationConfig> context) {
+    public boolean test(Target<Entity> entity, RequirementContext<Entity, LocationConfig> context) {
 
         if (!context.getConfig().isPresent()) return true;
 
         return context.getConfig()
-                .map(locationConfig -> locationConfig.isWithinRadius(entity.getLocation()))
+                .map(locationConfig -> locationConfig.isWithinRadius(entity.getSource().getLocation()))
                 .orElse(true);
     }
 }

--- a/art-example/src/main/java/net/silthus/examples/art/targets/EntityTarget.java
+++ b/art-example/src/main/java/net/silthus/examples/art/targets/EntityTarget.java
@@ -1,0 +1,16 @@
+package net.silthus.examples.art.targets;
+
+import net.silthus.art.api.trigger.AbstractTarget;
+import org.bukkit.entity.Entity;
+
+public class EntityTarget extends AbstractTarget<Entity> {
+
+    public EntityTarget(Entity source) {
+        super(source);
+    }
+
+    @Override
+    public String getUniqueId() {
+        return getSource().getUniqueId().toString();
+    }
+}

--- a/art-example/src/main/java/net/silthus/examples/art/targets/PlayerTarget.java
+++ b/art-example/src/main/java/net/silthus/examples/art/targets/PlayerTarget.java
@@ -26,6 +26,6 @@ public class PlayerTarget extends AbstractTarget<Player> {
     }
 
     public String getUniqueId() {
-        return getTarget().getUniqueId().toString();
+        return getSource().getUniqueId().toString();
     }
 }

--- a/art-example/src/test/java/net/silthus/examples/art/requirements/EntityLocationRequirementTest.java
+++ b/art-example/src/test/java/net/silthus/examples/art/requirements/EntityLocationRequirementTest.java
@@ -19,7 +19,9 @@ package net.silthus.examples.art.requirements;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import net.silthus.art.api.requirements.RequirementContext;
+import net.silthus.art.api.trigger.Target;
 import net.silthus.examples.art.configs.LocationConfig;
+import net.silthus.examples.art.targets.EntityTarget;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
@@ -49,16 +51,16 @@ class EntityLocationRequirementTest {
 
     private final EntityLocationRequirement requirement = new EntityLocationRequirement();
 
-    private Entity withEntityAt(int x, int y, int z, String world) {
+    private Target<Entity> withEntityAt(int x, int y, int z, String world) {
         World worldMock = mock(World.class);
         when(worldMock.getName()).thenReturn(world);
         Location location = new Location(worldMock, x, y, z);
         Entity entity = mock(Entity.class);
         when(entity.getLocation()).thenReturn(location);
-        return entity;
+        return new EntityTarget(entity);
     }
 
-    private Entity withEntityAt(int x, int y, int z) {
+    private Target<Entity> withEntityAt(int x, int y, int z) {
         return withEntityAt(x, y, z, "world");
     }
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -73,13 +73,17 @@ public class PlayerDamageAction implements Action<Player, PlayerDamageAction.Act
     /**
      * This method will be called everytime your action is executed.
      *
-     * @param player the player or other target object your action is executed against
+     * @param target the player or other target object your action is executed against
      * @param context context of this action.
      *                Use the {@link ActionContext} to retrieve the config
      */
     @Override
-    public void execute(Player player, ActionContext<Player, ActionConfig> context) {
+    public void execute(Target<Player> target, ActionContext<Player, ActionConfig> context) {
         context.getConfig().ifPresent(config -> {
+            // the target object is always wrapped in a Target<?> class
+            // this makes it easy to provide a consistent unique id across different targets
+            // use the target.getUniqueId() method if you want to cache something related to the given target instance
+            Player player = target.getSource();
             double damage;
             double health = player.getHealth();
             double maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
@@ -153,12 +157,12 @@ See the comments on the [action-example](#creating-actions) for details on the a
 public class EntityLocationRequirement implements Requirement<Entity, LocationConfig> {
 
     @Override
-    public boolean test(Entity entity, RequirementContext<Entity, LocationConfig> context) {
+    public boolean test(Target<Entity> entity, RequirementContext<Entity, LocationConfig> context) {
 
         if (!context.getConfig().isPresent()) return true;
 
         return context.getConfig()
-                .map(locationConfig -> locationConfig.isWithinRadius(entity.getLocation()))
+                .map(locationConfig -> locationConfig.isWithinRadius(entity.getSource().getLocation()))
                 .orElse(true);
     }
 }


### PR DESCRIPTION
The Target class wraps the real target and provides a way to get a consistent unique identifier.

BREAKING CHANGE: the text(...) and execute(...) methods of Requirements and Actions must be changed to accept a Target<TSource>, e.g. Target<Player>